### PR TITLE
Compile with the new builtin syntax

### DIFF
--- a/src/struct_mapping.zig
+++ b/src/struct_mapping.zig
@@ -84,7 +84,7 @@ fn setValue(ctx: *Context, comptime T: type, dest: *T, value: *const Value) !voi
         .Int => {
             switch (value.*) {
                 .integer => |x| {
-                    dest.* = @intCast(@TypeOf(dest.*), x);
+                    dest.* = @intCast(x);
                 },
                 else => return error.InvalidValueType,
             }
@@ -92,10 +92,10 @@ fn setValue(ctx: *Context, comptime T: type, dest: *T, value: *const Value) !voi
         .Float => {
             switch (value.*) {
                 .float => |x| {
-                    dest.* = @floatCast(@TypeOf(dest.*), x);
+                    dest.* = @floatCast(x);
                 },
                 .integer => |x| {
-                    dest.* = @intToFloat(@TypeOf(dest.*), x);
+                    dest.* = @floatFromInt(x);
                 },
                 else => return error.InvalidValueType,
             }


### PR DESCRIPTION
This PR allows the library to compile with the latest master version of the Zig compiler.

The relevant compiler changes are in these two PRs: ziglang/zig#16046 and ziglang/zig#16163. They change the cast builtins to infer the result type and change the order of the conversion builtins to `@xFromY` instead of `@yToX`.