### PR TITLE
Make API better (arena + no leak memory)

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,6 +22,7 @@ This is a top-down LL parser that parses directly into Zig structs.
   * [x] Date, time, date-time, time offset
 * Struct mapping
   * [x] Mapping to structs
+  * [x] Mapping to enums
   * [x] Mapping to slices
   * [ ] Mapping to arrays
   * [x] Mapping to pointers

--- a/src/main.zig
+++ b/src/main.zig
@@ -56,14 +56,14 @@ pub fn Parser(comptime Target: type) type {
             }
         }
 
-        pub fn parseFile(self: *Self, filename: []const u8, dest: *Target) !void {
+        pub fn parseFile(self: *Self, filename: []const u8) !Parsed(Target) {
             const file = try std.fs.cwd().openFile(filename, .{});
             defer file.close();
 
             var content = try file.readToEndAlloc(self.alloc, 1024 * 1024 * 1024);
             defer self.alloc.free(content);
 
-            return self.parseString(content, dest);
+            return self.parseString(content);
         }
 
         pub fn parseString(self: *Self, input: []const u8) !Parsed(Target) {

--- a/src/struct_mapping.zig
+++ b/src/struct_mapping.zig
@@ -157,6 +157,21 @@ fn setValue(ctx: *Context, comptime T: type, dest: *T, value: *const Value) !voi
         .Optional => |tinfo| {
             try setValue(ctx, tinfo.child, &dest.*.?, value);
         },
+        .Enum => |tinfo| {
+            switch (value.*) {
+                .string => |s| {
+                    inline for (tinfo.fields) |field| {
+                        if (std.mem.eql(u8, field.name, s)) {
+                            dest.* = @enumFromInt(field.value);
+                            break;
+                        }
+                    } else {
+                        return error.InvalidValueType;
+                    }
+                },
+                else => return error.InvalidValueType,
+            }
+        },
         else => return error.NotSupportedFieldType,
     }
 }

--- a/src/table.zig
+++ b/src/table.zig
@@ -182,6 +182,7 @@ pub fn parseInlineTable(ctx: *parser.Context) !?*Table {
     return table;
 }
 
+/// Deprecated: use `Parsed(Target).deinit` instead
 pub fn deinitTableRecursively(table: *Table) void {
     var it = table.iterator();
     while (it.next()) |entry| {


### PR DESCRIPTION
`Parsed` is `std.json.Parsed` but simpler