### PR TITLE
Fix for latest Zig master

### DIFF
--- a/build.zig
+++ b/build.zig
@@ -5,7 +5,7 @@ pub fn build(b: *std.Build) void {
     const targetOpt = b.standardTargetOptions(.{});
 
     const module = b.addModule("zig-toml", .{
-        .source_file = std.Build.FileSource.relative("src/main.zig"),
+        .root_source_file = .{ .path = "src/main.zig" },
     });
 
     const main_tests = b.addTest(.{
@@ -21,9 +21,10 @@ pub fn build(b: *std.Build) void {
     const example1 = b.addExecutable(.{
         .name = "example1",
         .root_source_file = .{ .path = "examples/example1.zig" },
+        .target = targetOpt,
         .optimize = optimizeOpt,
     });
-    example1.addModule("zig-toml", module);
+    example1.root_module.addImport("zig-toml", module);
     b.installArtifact(example1);
 
     const run_example1 = b.addRunArtifact(example1);

--- a/src/array.zig
+++ b/src/array.zig
@@ -17,7 +17,7 @@ pub fn parse(ctx: *parser.Context) !?*value.ValueList {
     errdefer ar.deinit();
 
     while (true) {
-        var val = try value.parse(ctx);
+        const val = try value.parse(ctx);
         try ar.append(val);
         comment.skipSpacesAndComments(ctx);
         parser.consumeString(ctx, ",") catch {};
@@ -35,7 +35,7 @@ test "array" {
         \\"aa", # comment
         \\[5], ]x
     );
-    var ar = (try parse(&ctx)).?;
+    const ar = (try parse(&ctx)).?;
 
     try testing.expect(ar.items.len == 4);
     try testing.expect(ar.items[0].integer == 3);

--- a/src/datetime.zig
+++ b/src/datetime.zig
@@ -42,8 +42,8 @@ pub fn interpretDate(txt: []const u8) DateError!?Date {
 }
 
 test "date" {
-    var d = Date{ .year = 2004, .month = 7, .day = 11 };
-    var d1 = try interpretDate("2004-07-11");
+    const d = Date{ .year = 2004, .month = 7, .day = 11 };
+    const d1 = try interpretDate("2004-07-11");
     try testing.expect(std.meta.eql(d, d1.?));
 
     try testing.expectError(DateError.InvalidYear, interpretDate("0x04-07-11"));
@@ -89,7 +89,7 @@ pub fn interpretTime(txt: []const u8) TimeError!?Time {
 }
 
 fn testTime(str: []const u8, expected: Time) !void {
-    var t = try interpretTime(str);
+    const t = try interpretTime(str);
     try testing.expect(std.meta.eql(t.?, expected));
 }
 
@@ -136,8 +136,8 @@ const OffsetError = error{
 
 fn interpretOffset(txt: []const u8) OffsetError!?i16 {
     if ((txt[0] == '+' or txt[0] == '-') and txt[3] == ':') {
-        var hour = std.fmt.parseInt(i16, txt[0..3], 10) catch return error.InvalidTimeOffset;
-        var minute = std.fmt.parseInt(i16, txt[4..], 10) catch return error.InvalidTimeOffset;
+        const hour = std.fmt.parseInt(i16, txt[0..3], 10) catch return error.InvalidTimeOffset;
+        const minute = std.fmt.parseInt(i16, txt[4..], 10) catch return error.InvalidTimeOffset;
         if (hour > 11 or hour < -11 or minute > 59) return error.InvalidTimeOffset;
         return hour * 60 + std.math.sign(hour) * minute;
     } else return null;
@@ -147,8 +147,8 @@ pub const DateTimeError = DateError || TimeError || OffsetError;
 
 pub fn interpretDateTime(txt: []const u8) DateTimeError!?DateTime {
     if (txt.len < 19 or txt[10] != 'T') return null;
-    var date = try interpretDate(txt[0..10]) orelse return null;
-    var time_with_offset = try interpretTimeAndOffset(txt[11..]) orelse return null;
+    const date = try interpretDate(txt[0..10]) orelse return null;
+    const time_with_offset = try interpretTimeAndOffset(txt[11..]) orelse return null;
     return DateTime{
         .date = date,
         .time = time_with_offset.time,
@@ -157,7 +157,7 @@ pub fn interpretDateTime(txt: []const u8) DateTimeError!?DateTime {
 }
 
 test "datetime" {
-    var dt = try interpretDateTime("2022-12-14T09:14:58.555555-02:30");
+    const dt = try interpretDateTime("2022-12-14T09:14:58.555555-02:30");
     try testing.expect(std.meta.eql(dt.?, DateTime{
         .date = Date{ .year = 2022, .month = 12, .day = 14 },
         .time = Time{ .hour = 9, .minute = 14, .second = 58, .nanosecond = 555555000 },

--- a/src/float.zig
+++ b/src/float.zig
@@ -7,7 +7,7 @@ pub fn interpret(txt: []const u8) ?f64 {
 }
 
 fn testFloat(str: []const u8, expected: f64) !void {
-    var x = testParse(str);
+    const x = testParse(str);
     try testing.expect(x == expected);
 }
 
@@ -35,6 +35,6 @@ test "float" {
     try std.testing.expect(std.math.isNan(testParse("+nan")));
     try std.testing.expect(std.math.isNan(testParse("-nan")));
 
-    var x = interpret("123e");
+    const x = interpret("123e");
     try testing.expect(x == null);
 }

--- a/src/integer.zig
+++ b/src/integer.zig
@@ -7,7 +7,7 @@ pub fn interpret(txt: []const u8) ?i64 {
 }
 
 fn testInt(str: []const u8, expected: i64) !void {
-    var x = interpret(str).?;
+    const x = interpret(str).?;
     try testing.expect(x == expected);
 }
 

--- a/src/key.zig
+++ b/src/key.zig
@@ -12,7 +12,7 @@ fn parseBareKey(ctx: *parser.Context) !parser.String {
     if (try string.parseSingleLine(ctx)) |v| {
         return parser.String{ .content = v, .allocated = true };
     } else {
-        var v = parser.takeWhile(ctx, isBareKeyChar);
+        const v = parser.takeWhile(ctx, isBareKeyChar);
         return parser.String.fromSlice(v);
     }
 }
@@ -50,7 +50,7 @@ fn parseDotted(ctx: *parser.Context, first: parser.String) !Key {
 
         _ = ctx.next();
         spaces.skipSpaces(ctx);
-        var next = try parseBareKey(ctx);
+        const next = try parseBareKey(ctx);
         try ar.append(next);
         spaces.skipSpaces(ctx);
     }
@@ -58,7 +58,7 @@ fn parseDotted(ctx: *parser.Context, first: parser.String) !Key {
 }
 
 pub fn parse(ctx: *parser.Context) !Key {
-    var first = try parseBareKey(ctx);
+    const first = try parseBareKey(ctx);
     spaces.skipSpaces(ctx);
     if (ctx.current()) |cur| {
         if (cur == '.') {
@@ -73,7 +73,7 @@ pub fn parse(ctx: *parser.Context) !Key {
 
 test "bare" {
     var ctx = parser.testInput("abc =");
-    var key = try parse(&ctx);
+    const key = try parse(&ctx);
     try testing.expect(std.mem.eql(u8, key.bare.content, "abc"));
     try testing.expect(ctx.current().? == '=');
 }

--- a/src/key_value_pair.zig
+++ b/src/key_value_pair.zig
@@ -17,11 +17,11 @@ pub const KeyValuePair = struct {
 };
 
 pub fn parse(ctx: *parser.Context) !KeyValuePair {
-    var k = try key.parse(ctx);
+    const k = try key.parse(ctx);
     spaces.skipSpaces(ctx);
     try parser.consumeString(ctx, "=");
     spaces.skipSpaces(ctx);
-    var v = try value.parse(ctx);
+    const v = try value.parse(ctx);
     return KeyValuePair{
         .key = k,
         .value = v,

--- a/src/main.zig
+++ b/src/main.zig
@@ -64,7 +64,7 @@ pub fn Parser(comptime Target: type) type {
             const file = try std.fs.cwd().openFile(filename, .{});
             defer file.close();
 
-            var content = try file.readToEndAlloc(self.alloc, 1024 * 1024 * 1024);
+            const content = try file.readToEndAlloc(self.alloc, 1024 * 1024 * 1024);
             defer self.alloc.free(content);
 
             return self.parseString(content);

--- a/src/parser.zig
+++ b/src/parser.zig
@@ -85,14 +85,14 @@ fn isA(x: u8) bool {
 
 test "takeWhile 1" {
     var ctx = testInput("aaabc");
-    var a3 = takeWhile(&ctx, isA);
+    const a3 = takeWhile(&ctx, isA);
     try testing.expect(std.mem.eql(u8, a3, "aaa"));
     try testing.expect(ctx.current().? == 'b');
 }
 
 test "takeWhile 2" {
     var ctx = testInput("aaa");
-    var a3 = takeWhile(&ctx, isA);
+    const a3 = takeWhile(&ctx, isA);
     try testing.expect(std.mem.eql(u8, a3, "aaa"));
     try testing.expect(ctx.current() == null);
 }

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -68,7 +68,7 @@ test "parse into struct" {
     defer p.deinit();
 
     const parsed = try p.parseFile("./test/doc1.toml.txt");
-    var aa: Aa = parsed.value;
+    const aa: Aa = parsed.value;
     defer parsed.deinit();
 
     try testing.expect(aa.aa == 34);

--- a/src/value.zig
+++ b/src/value.zig
@@ -104,7 +104,7 @@ fn isScalarChar(c: u8) bool {
 
 fn parseScalar(ctx: *parser.Context) !?Value {
     var sc = ctx.*;
-    var txt = parser.takeWhile(&sc, isScalarChar);
+    const txt = parser.takeWhile(&sc, isScalarChar);
 
     var val: Value = undefined;
     if (integer.interpret(txt)) |x| {
@@ -119,8 +119,8 @@ fn parseScalar(ctx: *parser.Context) !?Value {
         if (sc.input.len > 9 and sc.input[0] == ' ') { // Space separator between date and time
             var sc2 = sc;
             _ = sc2.next();
-            var txt2 = parser.takeWhile(&sc2, isScalarChar);
-            var to = try datetime.interpretTimeAndOffset(txt2) orelse return error.InvalidTime;
+            const txt2 = parser.takeWhile(&sc2, isScalarChar);
+            const to = try datetime.interpretTimeAndOffset(txt2) orelse return error.InvalidTime;
             val = Value{ .datetime = datetime.DateTime{
                 .date = x,
                 .time = to.time,
@@ -141,7 +141,7 @@ fn parseScalar(ctx: *parser.Context) !?Value {
 
 fn testScalar(txt: []const u8, expected: Value) !void {
     var ctx = parser.testInput(txt);
-    var parsed = try parseScalar(&ctx);
+    const parsed = try parseScalar(&ctx);
     try testing.expect(std.meta.eql(parsed.?, expected));
 }
 
@@ -173,7 +173,7 @@ test "bool" {
     try testing.expect(interpretBool("false").? == false);
 
     var ctx = parser.testInput("true");
-    var val = try parse(&ctx);
+    const val = try parse(&ctx);
     try testing.expect(val.boolean == true);
 }
 


### PR DESCRIPTION
The build.zig file needed to be updated
as a result of some recent build system changes,

On top of that, it is now a compile-time error to declare a `var`
and then not mutate it. These cases must use `const` instead.
