### PR TITLE
ci: Test with 0.11 and master, fix for both

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -6,12 +6,17 @@ on:
   pull_request: {}
 jobs:
   build_and_test:
+    strategy:
+      matrix:
+        zig-version: ['0.11.0', 'master']
+
     runs-on: ubuntu-latest
+    name: Test / Zig ${{ matrix.zig-version }}
     steps:
       - uses: actions/checkout@v2
       - uses: goto-bus-stop/setup-zig@v1
         with:
-          version: master
-      - run: zig fmt --check *.zig src/*.zig
+          version: ${{ matrix.zig-version }}
+      - run: zig fmt --check ./*.zig src/*.zig
       - run: zig build test
       - run: zig build

--- a/build.zig
+++ b/build.zig
@@ -4,9 +4,13 @@ pub fn build(b: *std.Build) void {
     const optimizeOpt = b.standardOptimizeOption(.{});
     const targetOpt = b.standardTargetOptions(.{});
 
-    const module = b.addModule("zig-toml", .{
-        .root_source_file = .{ .path = "src/main.zig" },
-    });
+    // FIXME: Delete this when Zig 0.12 is released
+    const is_zig_0_11 = @hasDecl(std.Build, "CreateModuleOptions");
+
+    const module = b.addModule("zig-toml", if (is_zig_0_11)
+        .{ .source_file = .{ .path = "src/main.zig" } }
+    else
+        .{ .root_source_file = .{ .path = "src/main.zig" } });
 
     const main_tests = b.addTest(.{
         .root_source_file = .{ .path = "src/tests.zig" },
@@ -24,7 +28,11 @@ pub fn build(b: *std.Build) void {
         .target = targetOpt,
         .optimize = optimizeOpt,
     });
-    example1.root_module.addImport("zig-toml", module);
+    if (is_zig_0_11) {
+        example1.addModule("zig-toml", module);
+    } else {
+        example1.root_module.addImport("zig-toml", module);
+    }
     b.installArtifact(example1);
 
     const run_example1 = b.addRunArtifact(example1);

--- a/examples/example1.zig
+++ b/examples/example1.zig
@@ -25,7 +25,7 @@ pub fn main() anyerror!void {
     var result = try parser.parseFile("./examples/example1.toml");
     defer result.deinit();
 
-    var config = result.value;
+    const config = result.value;
     std.debug.print("{s}\nlocal address: {s}:{}\n", .{ config.description, config.local.host, config.local.port });
     std.debug.print("peer0: {s}:{}\n", .{ config.peers[0].host, config.peers[0].port });
 }


### PR DESCRIPTION
Adds support for building with both, Zig 0.11 and master.
The special-casing can be dropped when 0.12 is released.

Also fixes one case in examples that was missed in #4.
