### PR TITLE
Fix parsing optionals in ReleaseFast build

### DIFF
--- a/.github/workflows/build-and-test.yml
+++ b/.github/workflows/build-and-test.yml
@@ -21,4 +21,5 @@ jobs:
           version: ${{ matrix.zig-version }}
       - run: zig fmt --check ./*.zig src/*.zig
       - run: zig build test
+      - run: zig build test --release=fast
       - run: zig build

--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
+.zig-cache/
 zig-cache/
 zig-out/

--- a/src/struct_mapping.zig
+++ b/src/struct_mapping.zig
@@ -160,6 +160,7 @@ fn setValue(ctx: *Context, comptime T: type, dest: *T, value: *const Value) !voi
             }
         },
         .Optional => |tinfo| {
+            dest.* = @as(tinfo.child, undefined);
             try setValue(ctx, tinfo.child, &dest.*.?, value);
         },
         .Enum => |tinfo| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -126,6 +126,32 @@ test "parse into struct" {
     try testing.expectEqualSlices(u8, "str2", aa.tab2.get("b").?.table.get("val").?.string);
 }
 
+test "optionals (--release=fast)" {
+    const Sub = struct {
+        id: u16,
+        name: []const u8,
+    };
+
+    const Opts = struct {
+        sub: ?Sub,
+    };
+
+    var p = main.Parser(Opts).init(testing.allocator);
+    defer p.deinit();
+
+    const parsed = try p.parseString(
+        \\ [sub]
+        \\ id = 12
+        \\ name = "world"
+    );
+    defer parsed.deinit();
+    const m = parsed.value;
+
+    try std.testing.expect(m.sub != null);
+    try std.testing.expectEqual(12, m.sub.?.id);
+    try std.testing.expectEqualStrings("world", m.sub.?.name);
+}
+
 test "deinit table" {
     var p = main.Parser(main.Table).init(testing.allocator);
     defer p.deinit();

--- a/src/value.zig
+++ b/src/value.zig
@@ -50,7 +50,9 @@ pub const Value = union(enum) {
     pub fn print(self: *const Value) void {
         switch (self.*) {
             .string => |x| std.debug.print("\"{s}\"", .{x}),
-            .integer, .float => |x| std.debug.print("{}", .{x}),
+            .integer => |x| std.debug.print("{}", .{x}),
+            .float => |x| std.debug.print("{}", .{x}),
+            .boolean => |x| std.debug.print("{}", .{x}),
             .date => |x| std.debug.print("{}-{}-{}", .{ x.year, x.month, x.day }),
             .time => |x| std.debug.print("{}:{}:{}.{}", .{ x.hour, x.minute, x.second, x.nanosecond }),
             .datetime => |x| std.debug.print("{}-{}-{}T{}:{}:{}.{}", .{ x.date.year, x.date.month, x.date.day, x.time.hour, x.time.minute, x.time.second, x.time.nanosecond }),


### PR DESCRIPTION
Parsing optionals fail at runtime when we use ReleaseFast optimization.
```zig
const std = @import("std");
const toml = @import("zig-toml");

const Opts = struct {
    sub: ?Sub,
};

const Sub = struct {
    id: u16,
    name: []const u8,
};

const config_toml =
    \\ [sub]
    \\ id = 1
    \\ name = "planet"
;

test "parse optional" {
    var gpa = std.heap.GeneralPurposeAllocator(.{}){};
    defer _ = gpa.deinit();
    const allocator = gpa.allocator();

    var parser = toml.Parser(Opts).init(allocator);
    defer parser.deinit();

    const parsed = try parser.parseString(config_toml);
    defer parsed.deinit();

    try std.testing.expect(parsed.value.sub != null);
    try std.testing.expectEqual(1, parsed.value.sub.?.id);
    try std.testing.expectEqualStrings("planet", parsed.value.sub.?.name);
}
```

Running the tests:
```sh
❯ zig build test
❯ zig build test --release=fast
test
└─ run test 0/1 passed, 1 failed
error: 'main.test.parse optional' failed
error: while executing test 'main.test.parse optional', the following test command failed:
/Users/leki/temp/zig/.zig-cache/o/d91ddfd592627a7bc8c892de1cb37bab/test --listen=- 
Build Summary: 1/3 steps succeeded; 1 failed; 0/1 tests passed; 1 failed (disable with --summary none)
test transitive failure
└─ run test 0/1 passed, 1 failed
error: the following build command failed with exit code 1:
/Users/leki/temp/zig/.zig-cache/o/c54e788abb8f5b1baf72e7ee2970d86b/build /opt/homebrew/Cellar/zig/0.13.0/bin/zig /Users/leki/temp/zig /Users/leki/temp/zig/.zig-cache /Users/leki/.cache/zig --seed 0xc50410e9 -Zd6d41f6c26d96811 test --release=fast
```