### PR TITLE
Add tests for serializer and more

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,8 @@ This is a top-down LL parser that parses directly into Zig structs.
     * [x] Basic types like `int`s, floating points, strings, booleans etc.
     * [x] Arrays
     * [x] Top level tables
-    * [ ] Inline tables
+    * [x] Sub tables
+    * [x] Pointer to basic types
 
 ## Example
 See [`example1.zig`](./examples/example1.zig) for the complete code that parses [`example.toml`](./examples/example1.toml)

--- a/build.zig
+++ b/build.zig
@@ -11,9 +11,16 @@ pub fn build(b: *std.Build) void {
         .target = targetOpt,
         .optimize = optimizeOpt,
     });
+    const serialize_tests = b.addTest(.{
+        .root_source_file = b.path("src/serialize/tests.zig"),
+        .target = targetOpt,
+        .optimize = optimizeOpt,
+    });
     const run_tests = b.addRunArtifact(main_tests);
+    const run_serialize_tests = b.addRunArtifact(serialize_tests);
     const test_step = b.step("test", "Run library tests");
     test_step.dependOn(&run_tests.step);
+    test_step.dependOn(&run_serialize_tests.step);
 
     // === examples
     const example1 = b.addExecutable(.{

--- a/src/serialize/root.zig
+++ b/src/serialize/root.zig
@@ -32,6 +32,7 @@ fn serializeStruct(state: *SerializerState, value: anytype, writer: *AnyWriter) 
 
     inline for (tinfo.@"struct".fields) |field| {
         const ftype = @typeInfo(field.type);
+
         if (ftype == .@"struct") {
             try state.table_level.append(field.name);
             try writer.writeByte('[');
@@ -39,12 +40,13 @@ fn serializeStruct(state: *SerializerState, value: anytype, writer: *AnyWriter) 
                 try writer.print("{s}.", .{state.table_level.items[i]});
             }
             try writer.print("{s}]\n", .{field.name});
-        } else try writer.print("{s} = ", .{field.name});
-        try serializeValue(state, ftype, @field(value, field.name), writer);
-
-        if (ftype == .@"struct") _ = state.table_level.popOrNull();
-
-        _ = try writer.write("\n");
+            try serializeValue(state, ftype, @field(value, field.name), writer);
+            _ = state.table_level.popOrNull();
+        } else {
+            try writer.print("{s} = ", .{field.name});
+            try serializeValue(state, ftype, @field(value, field.name), writer);
+            _ = try writer.write("\n");
+        }
     }
 }
 

--- a/src/serialize/root.zig
+++ b/src/serialize/root.zig
@@ -52,7 +52,18 @@ fn serializeStruct(state: *SerializerState, value: anytype, writer: *AnyWriter) 
 
 fn serializeValue(state: *SerializerState, t: std.builtin.Type, value: anytype, writer: *AnyWriter) !void {
     switch (t) {
-        .int, .float, .comptime_int, .comptime_float => try writer.print("{d}", .{value}),
+        .int, .float, .comptime_int, .comptime_float => {
+            if (t == .float) {
+                if (value == std.math.inf(@TypeOf(value))) {
+                    try writer.print("inf", .{});
+                    return;
+                } else if (value == -std.math.inf(@TypeOf(value))) {
+                    try writer.print("-inf", .{});
+                    return;
+                }
+            }
+            try writer.print("{d}", .{value});
+        },
         .bool => if (value) try writer.print("true", .{}) else try writer.print("false", .{}),
         .pointer => {
             const has_string_type = (t.pointer.child == u8 or (@typeInfo(t.pointer.child) == .array and @typeInfo(t.pointer.child).array.child == u8));

--- a/src/serialize/root.zig
+++ b/src/serialize/root.zig
@@ -36,11 +36,20 @@ fn serializeValue(allocator: Allocator, t: std.builtin.Type, value: anytype, wri
 
                 var curr_pos: usize = 0;
                 while (curr_pos <= string.len) {
-                    const new_pos = std.mem.indexOfAnyPos(u8, string, curr_pos, &.{'\"'}) orelse string.len;
+                    const new_pos = std.mem.indexOfAnyPos(u8, string, curr_pos, &.{ '"', '\n', '\t', '\r', '\\', 0x0C, 0x08 }) orelse string.len;
                     try writer.print("{s}", .{string[curr_pos..new_pos]});
                     if (new_pos != string.len) {
                         _ = try writer.writeByte('\\');
-                        _ = try writer.writeByte(string[new_pos]);
+                        switch (string[new_pos]) {
+                            '"' => _ = try writer.writeByte('"'),
+                            '\n' => _ = try writer.writeByte('n'),
+                            '\t' => _ = try writer.writeByte('t'),
+                            '\r' => _ = try writer.writeByte('r'),
+                            '\\' => _ = try writer.writeByte('\\'),
+                            0x0C => _ = try writer.writeByte('f'),
+                            0x08 => _ = try writer.writeByte('b'),
+                            else => unreachable,
+                        }
                     }
                     curr_pos = new_pos + 1;
                 }

--- a/src/serialize/root.zig
+++ b/src/serialize/root.zig
@@ -75,7 +75,7 @@ fn serializeValue(state: *SerializerState, t: std.builtin.Type, value: anytype, 
         },
         .bool => if (value) try writer.print("true", .{}) else try writer.print("false", .{}),
         .pointer => {
-            const has_string_type = (t.pointer.child == u8 or (@typeInfo(t.pointer.child) == .array and @typeInfo(t.pointer.child).array.child == u8));
+            const has_string_type = ((t.pointer.child == u8 and t.pointer.size == .slice) or (@typeInfo(t.pointer.child) == .array and @typeInfo(t.pointer.child).array.child == u8));
             if (has_string_type and t.pointer.is_const) {
                 _ = try writer.writeByte('"');
                 const string = value;
@@ -99,8 +99,10 @@ fn serializeValue(state: *SerializerState, t: std.builtin.Type, value: anytype, 
                     }
                     curr_pos = new_pos + 1;
                 }
+                _ = try writer.writeByte('"');
+            } else {
+                try serializeValue(state, @typeInfo(t.pointer.child), value.*, writer);
             }
-            _ = try writer.writeByte('"');
         },
         .array => {
             try writer.print("[ ", .{});

--- a/src/serialize/root.zig
+++ b/src/serialize/root.zig
@@ -1,131 +1,70 @@
 const std = @import("std");
 const testing = std.testing;
-const Allocator = std.testing.allocator;
 const AnyWriter = std.io.AnyWriter;
+const Allocator = std.mem.Allocator;
 
-const MAX_FIELD_COUNT: u8 = 255;
-
-pub fn serialize(allocator: std.mem.Allocator, obj: anytype, writer: *AnyWriter) !void {
-    try serializeStruct(allocator, obj, writer);
+pub fn serialize(allocator: Allocator, obj: anytype, writer: *AnyWriter) !void {
+    const ttype = @TypeOf(obj);
+    const tinfo = @typeInfo(ttype);
+    try serializeValue(allocator, tinfo, obj, writer);
 }
 
-fn serializeStruct(allocator: std.mem.Allocator, value: anytype, writer: *AnyWriter) !void {
+fn serializeStruct(allocator: Allocator, value: anytype, writer: *AnyWriter) !void {
     const ttype = @TypeOf(value);
     const tinfo = @typeInfo(ttype);
     if (tinfo != .@"struct") @panic("non struct type given to serialize");
 
     inline for (tinfo.@"struct".fields) |field| {
-        try serializeField(allocator, @typeInfo(field.type), field.name, @field(value, field.name), writer);
+        if (@typeInfo(field.type) == .@"struct")
+            try writer.print("[{s}]\n", .{field.name})
+        else
+            try writer.print("{s} = ", .{field.name});
+        try serializeValue(allocator, @typeInfo(field.type), @field(value, field.name), writer);
         _ = try writer.write("\n");
     }
 }
 
-fn serializeSimpleValue(allocator: std.mem.Allocator, t: std.builtin.Type, value: anytype, writer: *AnyWriter) !void {
+fn serializeValue(allocator: Allocator, t: std.builtin.Type, value: anytype, writer: *AnyWriter) !void {
     switch (t) {
-        .int, .float => try writer.print("{d}", .{value}),
+        .int, .float, .comptime_int, .comptime_float => try writer.print("{d}", .{value}),
         .bool => if (value) try writer.print("true", .{}) else try writer.print("false", .{}),
         .pointer => {
-            if (t.pointer.child == u8 and t.pointer.size == .slice and t.pointer.is_const) {
-                var esc_string = std.ArrayList(u8).init(allocator);
-                defer esc_string.deinit();
+            const has_string_type = (t.pointer.child == u8 or (@typeInfo(t.pointer.child) == .array and @typeInfo(t.pointer.child).array.child == u8));
+            if (has_string_type and t.pointer.is_const) {
+                _ = try writer.writeByte('"');
                 const string = value;
 
                 var curr_pos: usize = 0;
                 while (curr_pos <= string.len) {
-                    const new_pos = std.mem.indexOfAnyPos(u8, string, curr_pos, &.{ '\\', '\"' }) orelse string.len;
-
-                    if (new_pos >= curr_pos) {
-                        try esc_string.appendSlice(string[curr_pos..new_pos]);
-                        if (new_pos != string.len) {
-                            try esc_string.append('\\');
-                            try esc_string.append(string[new_pos]);
-                        }
-                        curr_pos = new_pos + 1;
+                    const new_pos = std.mem.indexOfAnyPos(u8, string, curr_pos, &.{'\"'}) orelse string.len;
+                    try writer.print("{s}", .{string[curr_pos..new_pos]});
+                    if (new_pos != string.len) {
+                        _ = try writer.writeByte('\\');
+                        _ = try writer.writeByte(string[new_pos]);
                     }
+                    curr_pos = new_pos + 1;
                 }
-                try writer.print("\"{s}\"", .{esc_string.items});
-            } else @panic("given type is not a simple type and cannot be serialized directly");
-        },
-        else => @panic("given type is not a simple type and cannot be serialized directly"),
-    }
-}
-
-fn serializeField(allocator: std.mem.Allocator, t: std.builtin.Type, key: []const u8, value: anytype, writer: *AnyWriter) !void {
-    switch (t) {
-        .int, .float, .bool => {
-            try writer.print("{s} = ", .{key});
-            try serializeSimpleValue(allocator, t, value, writer);
-        },
-        .pointer => {
-            try writer.print("{s} = ", .{key});
-            if (t.pointer.child == u8 and t.pointer.size == .slice and t.pointer.is_const)
-                try serializeSimpleValue(allocator, t, value, writer);
+            }
+            _ = try writer.writeByte('"');
         },
         .array => {
-            try writer.print("{s} = [ ", .{key});
+            try writer.print("[ ", .{});
             if (t.array.len != 0) {
                 var i: usize = 0;
                 while (i < t.array.len - 1) {
                     const elm = value[i];
-                    try serializeSimpleValue(allocator, @typeInfo(t.array.child), elm, writer);
+                    try serializeValue(allocator, @typeInfo(t.array.child), elm, writer);
                     try writer.print(", ", .{});
                     i += 1;
                 }
             }
             const elm = value[t.array.len - 1];
-            try serializeSimpleValue(allocator, @typeInfo(t.array.child), elm, writer);
+            try serializeValue(allocator, @typeInfo(t.array.child), elm, writer);
             try writer.print(" ]", .{});
         },
         .@"struct" => {
-            try writer.print("[{s}]\n", .{key});
             try serializeStruct(allocator, value, writer);
         },
         else => {},
     }
-}
-
-fn getFields(tinfo: std.builtin.Type) std.BoundedArray(std.builtin.Type.StructField, MAX_FIELD_COUNT) {
-    comptime var field_names = std.BoundedArray(std.builtin.Type.StructField, MAX_FIELD_COUNT).init(0) catch unreachable;
-    comptime var i: u8 = 0;
-    const fields = tinfo.@"struct".fields;
-    if (fields.len > MAX_FIELD_COUNT) @panic("struct field count exceeded MAX_FIELD_COUNT");
-    inline while (i < fields.len) {
-        const f = fields.ptr[i];
-        field_names.append(f) catch unreachable;
-        i += 1;
-    }
-    return field_names;
-}
-
-test "basic test" {
-    const TestStruct2 = struct {
-        field1: i32,
-    };
-
-    const TestStruct = struct {
-        field1: i32,
-        field2: []const u8,
-        field3: bool,
-        field4: f64,
-        field5: [5]u8,
-        field6: [5][]const u8,
-        field7: TestStruct2,
-    };
-
-    const t = TestStruct{
-        .field1 = 1024,
-        .field2 = "hello \" \\\" \" world",
-        .field3 = false,
-        .field4 = 3.14,
-        .field5 = [_]u8{ 1, 2, 3, 4, 5 },
-        .field6 = [_][]const u8{ "This", "is", "a", "text", "line" },
-        .field7 = .{ .field1 = 10 },
-    };
-
-    var buf: [1024]u8 = undefined;
-    var stream = std.io.fixedBufferStream(&buf);
-    var gwriter = stream.writer();
-    var writer = gwriter.any();
-    try serialize(Allocator, t, &writer);
-    std.debug.print("\n{s}", .{buf});
 }

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -149,7 +149,7 @@ test "structs" {
     try testing.expectEqualSlices(u8, result, ba.constSlice());
 }
 
-test "top level structs" {
+test "top level tables" {
     var ba = try std.BoundedArray(u8, 512).init(0);
     var writer = ba.writer().any();
 
@@ -186,6 +186,59 @@ test "top level structs" {
         \\field6 = [ "This", "is", "a", "text", "line" ]
         \\[field7]
         \\field1 = 10
+        \\
+        \\
+    ;
+
+    try serialize(Allocator, t, &writer);
+    try testing.expectEqualSlices(u8, result, ba.constSlice());
+}
+
+test "sub tables" {
+    var ba = try std.BoundedArray(u8, 512).init(0);
+    var writer = ba.writer().any();
+
+    const TestStruct3 = struct {
+        field1: i32,
+    };
+
+    const TestStruct2 = struct {
+        field1: i32,
+        field2: TestStruct3,
+    };
+
+    const TestStruct = struct {
+        field1: i32,
+        field2: []const u8,
+        field3: bool,
+        field4: f64,
+        field5: [5]u8,
+        field6: [5][]const u8,
+        field7: TestStruct2,
+    };
+
+    const t = TestStruct{
+        .field1 = 100,
+        .field2 = "hello world",
+        .field3 = true,
+        .field4 = 3.14,
+        .field5 = [_]u8{ 1, 2, 3, 4, 5 },
+        .field6 = [_][]const u8{ "This", "is", "a", "text", "line" },
+        .field7 = .{ .field1 = 10, .field2 = .{ .field1 = 100 } },
+    };
+
+    const result =
+        \\field1 = 100
+        \\field2 = "hello world"
+        \\field3 = true
+        \\field4 = 3.14
+        \\field5 = [ 1, 2, 3, 4, 5 ]
+        \\field6 = [ "This", "is", "a", "text", "line" ]
+        \\[field7]
+        \\field1 = 10
+        \\[field7.field2]
+        \\field1 = 100
+        \\
         \\
         \\
     ;

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -170,6 +170,50 @@ test "structs" {
     try testing.expectEqualSlices(u8, result, ba.constSlice());
 }
 
+test "tables follow top level fields" {
+    var ba = try std.BoundedArray(u8, 512).init(0);
+    var writer = ba.writer().any();
+
+    const TestStruct2 = struct {
+        field1: i32,
+    };
+
+    const TestStruct = struct {
+        field1: i32,
+        field2: []const u8,
+        field3: bool,
+        field4: f64,
+        field7: TestStruct2,
+        field5: [5]u8,
+        field6: [5][]const u8,
+    };
+
+    const t = TestStruct{
+        .field1 = 100,
+        .field2 = "hello world",
+        .field3 = true,
+        .field4 = 3.14,
+        .field5 = [_]u8{ 1, 2, 3, 4, 5 },
+        .field6 = [_][]const u8{ "This", "is", "a", "text", "line" },
+        .field7 = .{ .field1 = 10 },
+    };
+
+    const result =
+        \\field1 = 100
+        \\field2 = "hello world"
+        \\field3 = true
+        \\field4 = 3.14
+        \\field5 = [ 1, 2, 3, 4, 5 ]
+        \\field6 = [ "This", "is", "a", "text", "line" ]
+        \\[field7]
+        \\field1 = 10
+        \\
+    ;
+
+    try serialize(Allocator, t, &writer);
+    try testing.expectEqualSlices(u8, result, ba.constSlice());
+}
+
 test "top level tables" {
     var ba = try std.BoundedArray(u8, 512).init(0);
     var writer = ba.writer().any();

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -187,7 +187,6 @@ test "top level tables" {
         \\[field7]
         \\field1 = 10
         \\
-        \\
     ;
 
     try serialize(Allocator, t, &writer);
@@ -238,8 +237,6 @@ test "sub tables" {
         \\field1 = 10
         \\[field7.field2]
         \\field1 = 100
-        \\
-        \\
         \\
     ;
 

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -1,0 +1,101 @@
+const std = @import("std");
+const serialize = @import("./root.zig").serialize;
+const testing = std.testing;
+const Allocator = testing.allocator;
+
+test "basic literals" {
+    var ba = try std.BoundedArray(u8, 16).init(0);
+    var writer = ba.writer().any();
+
+    // Comptime integers
+    try serialize(Allocator, 127, &writer);
+    try testing.expectEqualSlices(u8, "127", ba.constSlice());
+    ba.clear();
+
+    try serialize(Allocator, -127, &writer);
+    try testing.expectEqualSlices(u8, "-127", ba.constSlice());
+    ba.clear();
+
+    // Runtime integers
+    var n: i16 = 127;
+    try serialize(Allocator, n, &writer);
+    try testing.expectEqualSlices(u8, "127", ba.constSlice());
+    ba.clear();
+
+    n = -127;
+    try serialize(Allocator, n, &writer);
+    try testing.expectEqualSlices(u8, "-127", ba.constSlice());
+    ba.clear();
+
+    // Booleans
+    try serialize(Allocator, true, &writer);
+    try testing.expectEqualSlices(u8, "true", ba.constSlice());
+    ba.clear();
+
+    try serialize(Allocator, false, &writer);
+    try testing.expectEqualSlices(u8, "false", ba.constSlice());
+    ba.clear();
+}
+
+test "strings" {
+    var ba = try std.BoundedArray(u8, 16).init(0);
+    var writer = ba.writer().any();
+
+    // Basic string
+    try serialize(Allocator, "hello world", &writer);
+    try testing.expectEqualSlices(u8, ba.constSlice(), "\"hello world\"");
+    ba.clear();
+
+    // String with escape chars
+    try serialize(Allocator, "hello\nworld", &writer);
+    try testing.expectEqualSlices(u8, ba.constSlice(), "\"hello\nworld\"");
+    ba.clear();
+
+    // String with escape quotes
+    try serialize(Allocator, "hello\"world", &writer);
+    try testing.expectEqualSlices(u8, ba.constSlice(), "\"hello\\\"world\"");
+    ba.clear();
+
+    // String with backslashes
+    try serialize(Allocator, "hello\\world", &writer);
+    try testing.expectEqualSlices(u8, "\"hello\\world\"", ba.constSlice());
+    ba.clear();
+
+    // String with escape quotes
+    try serialize(Allocator, "hello\\\"world", &writer);
+    try testing.expectEqualSlices(u8, ba.constSlice(), "\"hello\\\\\"world\"");
+    ba.clear();
+}
+
+test "basic test" {
+    const TestStruct2 = struct {
+        field1: i32,
+    };
+
+    const TestStruct = struct {
+        field1: i32,
+        field2: []const u8,
+        field3: bool,
+        field4: f64,
+        field5: [5]u8,
+        field6: [5][]const u8,
+        field7: TestStruct2,
+    };
+
+    const t = TestStruct{
+        .field1 = 1024,
+        .field2 = "hello \" \\\" \" world",
+        .field3 = false,
+        .field4 = 3.14,
+        .field5 = [_]u8{ 1, 2, 3, 4, 5 },
+        .field6 = [_][]const u8{ "This", "is", "a", "text", "line" },
+        .field7 = .{ .field1 = 10 },
+    };
+
+    var buf: [1024]u8 = undefined;
+    var stream = std.io.fixedBufferStream(&buf);
+    var gwriter = stream.writer();
+    var writer = gwriter.any();
+    try serialize(Allocator, t, &writer);
+    std.debug.print("\n{s}", .{buf});
+}

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -37,6 +37,27 @@ test "basic literals" {
     ba.clear();
 }
 
+test "infinities" {
+    var ba = try std.BoundedArray(u8, 16).init(0);
+    var writer = ba.writer().any();
+
+    try serialize(Allocator, std.math.inf(f32), &writer);
+    try testing.expectEqualSlices(u8, "inf", ba.constSlice());
+    ba.clear();
+
+    try serialize(Allocator, -std.math.inf(f32), &writer);
+    try testing.expectEqualSlices(u8, "-inf", ba.constSlice());
+    ba.clear();
+
+    try serialize(Allocator, std.math.inf(f64), &writer);
+    try testing.expectEqualSlices(u8, "inf", ba.constSlice());
+    ba.clear();
+
+    try serialize(Allocator, -std.math.inf(f64), &writer);
+    try testing.expectEqualSlices(u8, "-inf", ba.constSlice());
+    ba.clear();
+}
+
 test "strings" {
     var ba = try std.BoundedArray(u8, 16).init(0);
     var writer = ba.writer().any();

--- a/src/serialize/tests.zig
+++ b/src/serialize/tests.zig
@@ -58,6 +58,16 @@ test "infinities" {
     ba.clear();
 }
 
+test "pointers" {
+    var ba = try std.BoundedArray(u8, 16).init(0);
+    var writer = ba.writer().any();
+
+    const num: u8 = 127;
+    try serialize(Allocator, &num, &writer);
+    try testing.expectEqualSlices(u8, "127", ba.constSlice());
+    ba.clear();
+}
+
 test "strings" {
     var ba = try std.BoundedArray(u8, 16).init(0);
     var writer = ba.writer().any();


### PR DESCRIPTION
This PR adds a whole bunch of tests for the `serialize` module and also adds support for sub-tables. It also includes a bunch of bug fixes like tables always come after top level fields etc and a lot of refactoring here and there.