### PR TITLE
Fix package build.zig.zon for master

### DIFF
--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,5 @@
 .{
-    .name = .zig_toml,
+    .name = .toml,
     .fingerprint = 0xdaafbfb07b8bd669,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0-dev.3197+1d8857bbe",

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,6 +1,6 @@
 .{
     .name = .toml,
-    .fingerprint = 0xdaafbfb07b8bd669,
+    .fingerprint = 0x12c55c5305785d6d,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0-dev.3197+1d8857bbe",
     .paths = .{

--- a/build.zig.zon
+++ b/build.zig.zon
@@ -1,5 +1,6 @@
 .{
-    .name = "zig-toml",
+    .name = .zig_toml,
+    .fingerprint = 0xdaafbfb07b8bd669,
     .version = "0.0.0",
     .minimum_zig_version = "0.14.0-dev.3197+1d8857bbe",
     .paths = .{


### PR DESCRIPTION
Since [e03bc7a](https://github.com/ziglang/zig/commit/e03bc7ac78820b7763d6ecd21cfa19653535f8d0) the package name inside `build.zig.zon` should be an enum variant and not a string literal.
In [95f0dce](https://github.com/ziglang/zig/commit/95f0dce7dae258fc2cf9947fdaad26d768902373) it's also suggested to avoid putting "zig-" in package names, so I removed that prefix.