### PR TITLE
fix calling of serialization

### DIFF
--- a/src/main.zig
+++ b/src/main.zig
@@ -14,7 +14,7 @@ pub const DateTime = datetime.DateTime;
 pub const Value = value.Value;
 pub const ValueList = value.ValueList;
 pub const HashMap = struct_mapping.HashMap;
-pub const tomlize = serialize.tomlize;
+pub const Serializer = serialize;
 
 pub const Position = parser.Position;
 pub const FieldPath = []const []const u8;


### PR DESCRIPTION
I opted for `Serializer` since `serialize` is the existing import, and this would better match the `Parser`.

My code currently works as:
```zig
try toml.Serializer.serialize(allocator, Config, &writer);
```

Happy to make updates if that'll help.

closes https://github.com/sam701/zig-toml/issues/32