### PR TITLE
Support TOML 1.1 inline tables

### DIFF
--- a/src/table.zig
+++ b/src/table.zig
@@ -177,6 +177,12 @@ pub fn parseInlineTable(ctx: *parser.Context) !?*Table {
             try parser.consumeString(ctx, "}");
             break;
         };
+
+        spaces.skipSpacesAndLineBreaks(ctx);
+        parser.consumeString(ctx, "}") catch {
+            continue;
+        };
+        break;
     }
 
     return table;
@@ -219,7 +225,7 @@ test "multi-line inline table" {
     var ctx = parser.testInput(
         \\{
         \\    aa = 3,
-        \\    bb.cc = 4
+        \\    bb.cc = 4,
         \\}
     );
     var m = (try parseInlineTable(&ctx)).?;

--- a/src/table.zig
+++ b/src/table.zig
@@ -167,12 +167,12 @@ pub fn parseInlineTable(ctx: *parser.Context) !?*Table {
     errdefer deinitTableRecursively(table);
 
     while (true) {
-        spaces.skipSpaces(ctx);
+        spaces.skipSpacesAndLineBreaks(ctx);
         var pair = try kv.parse(ctx);
         errdefer pair.deinit(ctx.alloc);
 
         try handleKeyPair(ctx, table, &pair);
-        spaces.skipSpaces(ctx);
+        spaces.skipSpacesAndLineBreaks(ctx);
         parser.consumeString(ctx, ",") catch {
             try parser.consumeString(ctx, "}");
             break;
@@ -207,6 +207,21 @@ test "table content" {
 
 test "inline table" {
     var ctx = parser.testInput("{ aa = 3, bb.cc = 4 }");
+    var m = (try parseInlineTable(&ctx)).?;
+    try testing.expect(m.count() == 2);
+    try testing.expect(m.get("aa").?.integer == 3);
+    try testing.expect(m.get("bb").?.table.get("cc").?.integer == 4);
+    deinitTableRecursively(m);
+    testing.allocator.destroy(m);
+}
+
+test "multi-line inline table" {
+    var ctx = parser.testInput(
+        \\{
+        \\    aa = 3,
+        \\    bb.cc = 4
+        \\}
+    );
     var m = (try parseInlineTable(&ctx)).?;
     try testing.expect(m.count() == 2);
     try testing.expect(m.get("aa").?.integer == 3);


### PR DESCRIPTION
Part of sam701/zig-toml#42.

This PR adds support for multi-line inline tables and trailing commas from TOML 1.1.

I haven't seen any other PRs related to TOML 1.1, and I don't see any tagged releases on this repo. If you're accepting contributions, are you happy with work towards TOML 1.1 merging straight to `main` or would you prefer a `toml-1-1` feature branch until full 1.1 support is merged? Let me know, I'm happy to help out with this. The code in this repo is really nicely structured.

