### PR TITLE
Support TOML 1.1 strings

### DIFF
--- a/src/string.zig
+++ b/src/string.zig
@@ -71,6 +71,7 @@ fn parseEscaped(ctx: *Context, delimiter: *const Delimiter, output: *Buffer) !vo
         'U' => try parseUnicode(ctx, 8, output),
         'b' => try output.append(ctx.alloc, 0x08),
         'f' => try output.append(ctx.alloc, 0x0c),
+        'e' => try output.append(ctx.alloc, 0x1b),
         't' => try output.append(ctx.alloc, '\t'),
         'n' => try output.append(ctx.alloc, '\n'),
         'r' => try output.append(ctx.alloc, '\r'),
@@ -283,9 +284,9 @@ test "double escape" {
 }
 
 test "simple escape" {
-    var ctx = parser.testInput("\"\\b\\t\\r\\n\\fa\"");
+    var ctx = parser.testInput("\"\\b\\e\\t\\r\\n\\fa\"");
     const str = try parse(&ctx);
-    try testing.expect(std.mem.eql(u8, str.?, "\x08\t\r\n\x0ca"));
+    try testing.expect(std.mem.eql(u8, str.?, "\x08\x1b\t\r\n\x0ca"));
     try testing.expect(ctx.current() == null);
     ctx.alloc.free(str.?);
 }

--- a/src/string.zig
+++ b/src/string.zig
@@ -66,6 +66,7 @@ fn parseEscaped(ctx: *Context, delimiter: *const Delimiter, output: *Buffer) !vo
     const c = ctx.next() orelse return error.UnexpectedEOF;
     _ = ctx.next() orelse return error.UnexpectedEOF;
     switch (c) {
+        'x' => try parseUnicode(ctx, 2, output),
         'u' => try parseUnicode(ctx, 4, output),
         'U' => try parseUnicode(ctx, 8, output),
         'b' => try output.append(ctx.alloc, 0x08),
@@ -224,6 +225,13 @@ test "simple" {
     const str = try parse(&ctx);
     try testing.expect(std.mem.eql(u8, str.?, "abc"));
     try testing.expect(ctx.current().? == '=');
+    ctx.alloc.free(str.?);
+}
+
+test "unicode 2" {
+    var ctx = parser.testInput("\"b\\xE4c\"");
+    const str = try parse(&ctx);
+    try testing.expect(std.mem.eql(u8, str.?, "bäc"));
     ctx.alloc.free(str.?);
 }
 


### PR DESCRIPTION
[TOML 1.1](https://github.com/toml-lang/toml/releases/tag/1.1.0) adds support for two new [escape sequences](https://toml.io/en/v1.1.0#string). This PR adds support for them.