### PR TITLE
Add opt-in strict mode for unknown keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,7 @@ This is a top-down LL parser that parses directly into Zig structs.
   * [x] Mapping to integer and floats with lower bit number than defined by TOML, i.e. `i16`, `f32`.
   * [x] Mapping to optional fields
   * [x] Mapping to HashMaps
+  * [x] Optional strict mode that rejects unknown keys (`disallow_unknown_fields`)
 * [ ] Serialization
     * [x] Basic types like integers, floating points, strings, booleans etc.
     * [x] Arrays
@@ -85,6 +86,23 @@ pub fn main(init: std.process.Init) anyerror!void {
     std.debug.print("{s}\nlocal address: {s}:{}\n", .{ config.description, config.local.host, config.local.port });
     std.debug.print("peer0: {s}:{}\n", .{ config.peers[0].host, config.peers[0].port });
 }
+```
+
+## Strict mode
+By default an unknown key in the TOML document (one with no matching struct field) is
+silently ignored, so a typo like `nam` instead of `name` goes unnoticed. Set
+`disallow_unknown_fields` on the parser to make such keys fail with `error.UnknownField`:
+
+```zig
+var parser = toml.Parser(Config).init(allocator);
+parser.options.disallow_unknown_fields = true;
+defer parser.deinit();
+
+const result = parser.parseFile(init.io, "./config.toml") catch |err| {
+    // On error.UnknownField, parser.error_info.?.unknown_fields lists every
+    // unrecognized key: `.path` names the table, `.keys` are the unknown keys.
+    return err;
+};
 ```
 
 ## Error Handling

--- a/src/root.zig
+++ b/src/root.zig
@@ -54,9 +54,21 @@ pub const serialize = @import("serialize/root.zig").serialize;
 pub const Position = parser.Position;
 pub const FieldPath = []const []const u8;
 
+pub const UnknownFields = struct {
+    /// Struct-field path to the table with the unknown keys; empty at root.
+    path: FieldPath,
+    keys: []const []const u8,
+};
+
 pub const ErrorInfo = union(enum) {
     parse: Position,
     struct_mapping: FieldPath,
+    unknown_fields: UnknownFields,
+};
+
+pub const Options = struct {
+    /// Fail with error.UnknownField on a key that matches no struct field.
+    disallow_unknown_fields: bool = false,
 };
 
 pub fn Parsed(comptime T: type) type {
@@ -75,6 +87,7 @@ pub fn Parser(comptime Target: type) type {
         const Self = @This();
 
         alloc: std.mem.Allocator,
+        options: Options = .{},
         error_info: ?ErrorInfo = null,
 
         pub fn init(alloc: std.mem.Allocator) Self {
@@ -91,11 +104,28 @@ pub fn Parser(comptime Target: type) type {
             if (self.error_info) |einfo| {
                 switch (einfo) {
                     .struct_mapping => |field_path| {
+                        for (field_path) |segment| self.alloc.free(segment);
                         self.alloc.free(field_path);
+                    },
+                    .unknown_fields => |uf| {
+                        for (uf.path) |segment| self.alloc.free(segment);
+                        self.alloc.free(uf.path);
+                        for (uf.keys) |key| self.alloc.free(key);
+                        self.alloc.free(uf.keys);
                     },
                     else => {},
                 }
             }
+            self.error_info = null;
+        }
+
+        fn dupeStrings(self: *Self, items: []const []const u8) ![]const []const u8 {
+            const copy = try self.alloc.alloc([]const u8, items.len);
+            errdefer self.alloc.free(copy);
+            for (items, 0..) |segment, i| {
+                copy[i] = try self.alloc.dupe(u8, segment);
+            }
+            return copy;
         }
 
         pub fn parseFile(self: *Self, io: std.Io, filename: []const u8) !Parsed(Target) {
@@ -140,11 +170,20 @@ pub fn Parser(comptime Target: type) type {
             }
 
             var mapping_ctx = struct_mapping.Context.init(alloc);
+            mapping_ctx.disallow_unknown_fields = self.options.disallow_unknown_fields;
 
             var dest: Target = undefined;
             struct_mapping.intoStruct(&mapping_ctx, Target, &dest, &tab) catch |err| {
                 self.freeErrorInfo();
-                self.error_info = ErrorInfo{ .struct_mapping = try self.alloc.dupe([]const u8, mapping_ctx.field_path.items) }; // i suspect this might leak memory (the outer array is copied, but not inner ones). But it doesn't seem to leak. Strange.
+                // dupe into the parser allocator so error_info outlives the arena
+                if (mapping_ctx.unknown_fields.items.len > 0) {
+                    self.error_info = ErrorInfo{ .unknown_fields = .{
+                        .path = try self.dupeStrings(mapping_ctx.field_path.items),
+                        .keys = try self.dupeStrings(mapping_ctx.unknown_fields.items),
+                    } };
+                } else {
+                    self.error_info = ErrorInfo{ .struct_mapping = try self.dupeStrings(mapping_ctx.field_path.items) };
+                }
                 return err;
             };
             return .{ .arena = arena, .value = dest };

--- a/src/struct_mapping.zig
+++ b/src/struct_mapping.zig
@@ -9,6 +9,8 @@ const datetime = @import("./datetime.zig");
 pub const Context = struct {
     alloc: std.mem.Allocator,
     field_path: std.ArrayListUnmanaged([]const u8),
+    disallow_unknown_fields: bool = false,
+    unknown_fields: std.ArrayListUnmanaged([]const u8) = .empty,
 
     pub fn init(alloc: std.mem.Allocator) Context {
         return .{
@@ -42,6 +44,14 @@ pub fn intoStruct(ctx: *Context, comptime T: type, dest: *T, table: *Table) !voi
                     } else return error.MissingRequiredField;
                 }
                 _ = ctx.field_path.pop();
+            }
+            if (ctx.disallow_unknown_fields and table.count() > 0) {
+                // matched keys were fetchRemove'd, so the rest are unknown; arena frees them
+                var it = table.iterator();
+                while (it.next()) |entry| {
+                    try ctx.unknown_fields.append(ctx.alloc, entry.key_ptr.*);
+                }
+                return error.UnknownField;
             }
             var it = table.iterator();
             while (it.next()) |entry| {

--- a/src/tests.zig
+++ b/src/tests.zig
@@ -9,6 +9,13 @@ comptime {
     _ = @import("./serialize/tests.zig");
 }
 
+fn containsStr(haystack: []const []const u8, needle: []const u8) bool {
+    for (haystack) |s| {
+        if (std.mem.eql(u8, s, needle)) return true;
+    }
+    return false;
+}
+
 test "full" {
     var p = main.Parser(main.Table).init(testing.allocator);
     defer p.deinit();
@@ -239,4 +246,69 @@ test "empty file into struct with a required field" {
     defer p.deinit();
 
     try testing.expectError(error.MissingRequiredField, p.parseFile(std.testing.io, "./test/empty.toml.txt"));
+}
+
+test "disallow unknown fields collects all unknown keys" {
+    const Cfg = struct {
+        name: []const u8,
+    };
+
+    var p = main.Parser(Cfg).init(testing.allocator);
+    p.options.disallow_unknown_fields = true;
+    defer p.deinit();
+
+    try testing.expectError(error.UnknownField, p.parseString(
+        \\name = "ok"
+        \\nam = "typo"
+        \\naem = "typo2"
+    ));
+
+    const info = p.error_info.?.unknown_fields;
+    try testing.expectEqual(@as(usize, 0), info.path.len);
+    try testing.expectEqual(@as(usize, 2), info.keys.len);
+    try testing.expect(containsStr(info.keys, "nam"));
+    try testing.expect(containsStr(info.keys, "naem"));
+}
+
+test "disallow unknown fields reports nested table keys" {
+    const Sub = struct {
+        id: i64,
+    };
+    const Cfg = struct {
+        sub: Sub,
+    };
+
+    var p = main.Parser(Cfg).init(testing.allocator);
+    p.options.disallow_unknown_fields = true;
+    defer p.deinit();
+
+    try testing.expectError(error.UnknownField, p.parseString(
+        \\[sub]
+        \\id = 1
+        \\extra = 2
+        \\bogus = 3
+    ));
+
+    const info = p.error_info.?.unknown_fields;
+    try testing.expectEqual(@as(usize, 1), info.path.len);
+    try testing.expectEqualStrings("sub", info.path[0]);
+    try testing.expectEqual(@as(usize, 2), info.keys.len);
+    try testing.expect(containsStr(info.keys, "extra"));
+    try testing.expect(containsStr(info.keys, "bogus"));
+}
+
+test "unknown fields are ignored by default" {
+    const Cfg = struct {
+        name: []const u8 = "default",
+    };
+
+    var p = main.Parser(Cfg).init(testing.allocator);
+    defer p.deinit();
+
+    const parsed = try p.parseString(
+        \\nam = "typo"
+    );
+    defer parsed.deinit();
+
+    try testing.expectEqualStrings("default", parsed.value.name);
 }


### PR DESCRIPTION
## Problem

An unknown key in a TOML document (a typo like `nam` for `name`) is silently dropped, so the field keeps its default and the mistake goes unnoticed.

## Solution

Opt-in strict mode, off by default, so existing callers are unaffected.

- `Parser.options.disallow_unknown_fields` toggles it. The parser had no  settings mechanism, so this adds an `Options` struct on the parser. (option name is seemed like golang the same option `DisallowUnknownFields`)
- When on, a key with no matching struct field fails with `error.UnknownField`.
- All unknown keys of the offending table are collected and exposed via `error_info.unknown_fields`: `.path` to the table, `.keys` the unknown key names.

Implements #50